### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Framework
 Demo
 ****
 
-Check https://transmutator.readthedocs.org/en/latest/demo.html
+Check https://transmutator.readthedocs.io/en/latest/demo.html
 
 
 ******************
@@ -47,7 +47,7 @@ Help is welcome to implement a nice tool today, and to make it better tomorrow!
 Ressources
 **********
 
-* Documentation: https://transmutator.readthedocs.org
+* Documentation: https://transmutator.readthedocs.io
 * PyPI: https://pypi.python.org/pypi/transmutator
 * Code repository: https://github.com/benoitbryon/transmutator
 * Bugtracker: https://github.com/benoitbryon/transmutator/issues

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ VERSION = open(os.path.join(here, 'VERSION')).read().strip()
 AUTHOR = u'Benoît Bryon'
 EMAIL = 'benoit@marmelune.net'
 LICENSE = 'BSD'
-URL = 'https://{name}.readthedocs.org/'.format(name=NAME)
+URL = 'https://{name}.readthedocs.io/'.format(name=NAME)
 CLASSIFIERS = [
     'License :: OSI Approved :: BSD License',
     'Development Status :: 1 - Planning',


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
